### PR TITLE
feat: add multi-core CPU and GPU acceleration support

### DIFF
--- a/.claude/skills/flask-backend/SKILL.md
+++ b/.claude/skills/flask-backend/SKILL.md
@@ -40,7 +40,11 @@ Keep `ruff check --select E9,F63,F7,F82 backend/` clean.
   side effects (env load), hence the `# noqa: F401` import in `server.py`.
 - `state.py` — shared in-memory queue state + cancellation primitives.
 - `db.py` — SQLite persistence of terminal job history (`db_init`, `load_persisted_jobs`).
-- `media.py` — builds ffprobe / HandBrake / ffmpeg command lines.
+- `media.py` — builds ffprobe / HandBrake / ffmpeg command lines; also the encoder
+  catalog + runtime detection (`ENCODER_CATALOG`, `available_encoders()` parsed from
+  `HandBrakeCLI --help`, `cpu_count()`). `build_handbrake_cmd(..., threads)` resolves the
+  `-e` name from the catalog, applies presets/`--encopts` thread caps only to software
+  encoders. The UI reads detected encoders + cpu count from `GET /api/capabilities`.
 - `immich_api.py` — Immich HTTP client + parsing/summary helpers.
 - `jobs.py` — job lifecycle, encode pipeline, the background worker, SSE broadcast.
 - `routes.py` — the Flask blueprint `bp` with all HTTP routes.

--- a/Dockerfile
+++ b/Dockerfile
@@ -30,6 +30,12 @@ FROM python:3.12-slim AS runtime
 # ffmpeg/ffprobe (photo recompression + codec probing) and HandBrakeCLI
 # (video re-encoding, software x265 works everywhere). `sips` is macOS-only and
 # intentionally absent here — the app degrades gracefully (RAW compression off).
+#
+# Debian's handbrake-cli is built WITHOUT the GPU encoders (NVENC/QSV), so only
+# the CPU encoders are detected at runtime here — software multi-core x265/AV1 is
+# the out-of-the-box path. To enable hardware encoding, swap in a HandBrake build
+# compiled with NVENC/QSV and pass the GPU device into the container (see the
+# "Hardware acceleration" section of the README and docker-compose.yml).
 RUN apt-get update \
     && apt-get install -y --no-install-recommends \
         ffmpeg \

--- a/README.md
+++ b/README.md
@@ -18,6 +18,8 @@ live progress.
 
 - Browse videos, photos or Live Photos, filtered by size.
 - Re-encode videos (HandBrake: x264 / x265 / AV1, optional resolution cap).
+- Hardware (GPU) encoding when available, auto-detected at runtime, plus a
+  selectable CPU-core count. See [Hardware acceleration](#hardware-acceleration).
 - Recompress JPEGs to a target size (ffmpeg, with a macOS `sips` fallback);
   optional opt-in RAW → JPEG.
 - Strip the hidden motion video from Live Photos.
@@ -131,6 +133,35 @@ Set in `.env` (see [`.env.example`](.env.example)):
 | `PORT`           | no       | Listen port (default `5050`)                         |
 | `HOST`           | no       | Dev-server bind address (default `127.0.0.1`)        |
 | `IMMICH_DB`      | no       | SQLite job-history path (default `./immich_recompress.db`) |
+
+## Hardware acceleration
+
+The encoder dropdown is detected at runtime from your `HandBrakeCLI` build, so
+you only see options that work. Hardware encoders are far faster and barely touch
+the CPU; software encoders compress best and expose a **CPU cores** slider
+(defaults to all cores — lower it to keep the machine responsive).
+
+| Platform | Hardware encoder | How to enable |
+| -------- | ---------------- | ------------- |
+| macOS | Apple VideoToolbox | Works out of the box. |
+| Linux + Intel/AMD | QSV / VAAPI | Pass `/dev/dri` (below) + a HandBrake build with QSV/VAAPI. |
+| Linux + NVIDIA | NVENC | [NVIDIA Container Toolkit](https://docs.nvidia.com/datacenter/cloud-native/container-toolkit/latest/install-guide.html) + GPU reservation (below) + a HandBrake build with NVENC. |
+
+> **Docker:** the stock image's Debian `handbrake-cli` has **no** GPU encoders, so
+> only CPU encoders appear — NVENC/QSV need a HandBrake build that includes them.
+> The passthrough wiring below (and in `docker-compose.yml`) is ready for one.
+
+```yaml
+services:
+  immich-recompress:
+    devices:
+      - /dev/dri:/dev/dri          # Intel/AMD (QSV / VAAPI)
+    deploy:                         # NVIDIA NVENC (needs the Container Toolkit)
+      resources:
+        reservations:
+          devices:
+            - { driver: nvidia, count: all, capabilities: [gpu] }
+```
 
 ## Project layout
 

--- a/backend/config.py
+++ b/backend/config.py
@@ -61,13 +61,6 @@ MIN_FREE_BYTES = 200 * 1024 ** 2   # safety buffer for the work dir
 TERMINAL_STATES = {"done", "downloaded", "encoded", "skipped",
                    "error", "cancelled", "discarded"}
 
-ENCODER_MAP = {
-    "x265": "x265",
-    "nvenc_h265": "nvenc_h265",
-    "qsv_h265": "qsv_h265",
-    "vce_h265": "vce_h265",
-}
-
 # Photos are only *compressed*, never converted: we recompress JPEG in place and
 # skip every other format (so the on-disk format never changes). RAW gets its
 # own message since converting it would also destroy the original.

--- a/backend/jobs.py
+++ b/backend/jobs.py
@@ -13,7 +13,7 @@ import time
 from werkzeug.utils import secure_filename
 
 from backend.config import (
-    BACKUP_DIR, ENCODER_MAP, JPEG_PHOTO_EXTS, RAW_PHOTO_EXTS, TERMINAL_STATES,
+    BACKUP_DIR, JPEG_PHOTO_EXTS, RAW_PHOTO_EXTS, TERMINAL_STATES,
     WORK_DIR, get_env, human_duration, human_size, utcnow_iso,
 )
 from backend.state import (
@@ -73,6 +73,7 @@ def new_job(asset_id, params):
         "photo_target_savings": params.get("photo_target_savings", 40),
         "compress_raw": params.get("compress_raw", False),
         "preset": params.get("preset", "medium"),
+        "threads": params.get("threads"),
         "resolution": params.get("resolution", "original"),
         "motion_action": params.get("motion_action", "remove"),
         "skip_codecs": params.get("skip_codecs", "hevc,av1"),
@@ -182,29 +183,52 @@ def load_persisted_jobs():
 
 
 
+_PCT_RE = re.compile(r"(\d+(?:\.\d+)?)\s*%")
+
+
 def _parse_pct(line):
-    """Extract a progress percentage (0–100 float) from a HandBrake output line."""
-    if "%" not in line:
+    """Extract a progress percentage (0–100 float) from a HandBrake output line.
+
+    Reads the number attached to the ``%`` sign rather than the first number in
+    the line: HandBrake's progress line is ``Encoding: task 1 of 1, 47.50 %``,
+    so a naive "first number 0–100" scan would lock onto the ``1`` in "task 1 of
+    1" and pin progress at 1%.
+    """
+    m = _PCT_RE.search(line)
+    if not m:
         return None
-    for token in line.replace("%", " ").split():
-        try:
-            val = float(token)
-            if 0.0 <= val <= 100.0:
-                return val
-        except ValueError:
-            continue
-    return None
+    try:
+        val = float(m.group(1))
+    except ValueError:
+        return None
+    return val if 0.0 <= val <= 100.0 else None
+
+
+def _progress_from_line(line):
+    """Progress % for the bar, or None. Only HandBrake's *encode* phase counts.
+
+    HandBrake's preview **scan** also runs 0→100% (``Scanning title 1 of 1,
+    preview 10, 100.00 %``) and finishes before the encode starts, so counting it
+    would slam the bar to 100% while the real work hasn't begun. Muxing/optimize
+    and activity-log lines carry no encode percentage either.
+    """
+    if not line.lstrip().startswith("Encoding"):
+        return None
+    return _parse_pct(line)
 
 
 def run_handbrake(cmd, asset_id, source_duration):
-    """Run HandBrakeCLI, parsing progress from stderr. Returns True on success.
+    """Run HandBrakeCLI, parsing progress from its output. Returns True on success.
 
-    HandBrakeCLI uses \\r (carriage return) for progress lines, not \\n, so we
-    read character-by-character and split on both terminators.
+    HandBrakeCLI writes the live ``Encoding: task 1 of 1, X %`` progress to
+    *stdout*, and its activity log (plus any error detail) to *stderr*, so we
+    merge stderr into stdout and read the combined stream — discarding stdout
+    (as before) would mean never seeing real encode progress. Progress lines use
+    \\r (carriage return), not \\n, so we read char-by-char and split on both.
     """
     try:
-        proc = subprocess.Popen(cmd, stdout=subprocess.DEVNULL,
-                                stderr=subprocess.PIPE, text=True, bufsize=0)
+        proc = subprocess.Popen(cmd, stdout=subprocess.PIPE,
+                                stderr=subprocess.STDOUT, text=True, bufsize=0)
     except (OSError, ValueError):
         update_job(asset_id, log="Failed to start HandBrakeCLI")
         emit_job_update(asset_id)
@@ -214,7 +238,7 @@ def run_handbrake(cmd, asset_id, source_duration):
     last_emit = 0.0
     buf = ""
     while True:
-        ch = proc.stderr.read(1)
+        ch = proc.stdout.read(1)
         if not ch:
             break
         if ch in ("\r", "\n"):
@@ -222,7 +246,7 @@ def run_handbrake(cmd, asset_id, source_duration):
             buf = ""
             if not line:
                 continue
-            pct = _parse_pct(line)
+            pct = _progress_from_line(line)
             changes = {"log": line}
             if pct is not None:
                 changes["progress"] = round(pct, 1)
@@ -236,8 +260,9 @@ def run_handbrake(cmd, asset_id, source_duration):
 
     # flush any remaining buffer (no trailing newline)
     if buf.strip():
-        pct = _parse_pct(buf.strip())
-        changes = {"log": buf.strip()}
+        line = buf.strip()
+        pct = _progress_from_line(line)
+        changes = {"log": line}
         if pct is not None:
             changes["progress"] = round(pct, 1)
         update_job(asset_id, **changes)
@@ -825,7 +850,7 @@ def process_motionphoto_job(env, asset_id, params):
         emit_job_update(asset_id)
         cmd = build_handbrake_cmd(src_path, out_path, params.get("encoder", "x265"),
                                   params.get("quality", 24), params.get("preset", "medium"),
-                                  params.get("resolution", "original"))
+                                  params.get("resolution", "original"), params.get("threads"))
         ok = run_handbrake(cmd, asset_id, src_duration)
         if not ok or not os.path.isfile(out_path):
             cancelled = is_cancelled(asset_id)
@@ -999,7 +1024,7 @@ def process_job(asset_id):
 
     cmd = build_handbrake_cmd(src_path, out_path, params.get("encoder", "x265"),
                               params.get("quality", 24), params.get("preset", "medium"),
-                              params.get("resolution", "original"))
+                              params.get("resolution", "original"), params.get("threads"))
     ok = run_handbrake(cmd, asset_id, src_duration)
     if not ok or not os.path.isfile(out_path):
         cancelled = is_cancelled(asset_id)

--- a/backend/media.py
+++ b/backend/media.py
@@ -1,13 +1,15 @@
 """Pure media tooling: ffprobe probing, HandBrake/ffmpeg command builders,
-free-space checks and the CSV job log. Holds no job state.
+encoder/CPU capability detection, free-space checks and the CSV job log.
+Holds no job state.
 """
 import csv
+import functools
 import json
 import os
 import shutil
 import subprocess
 
-from backend.config import CSV_LOG, ENCODER_MAP, MIN_FREE_BYTES, WORK_DIR
+from backend.config import CSV_LOG, MIN_FREE_BYTES, WORK_DIR
 
 def has_free_space(num_bytes):
     """True if the work dir has room for ~2.5x the asset (src + out + backup)."""
@@ -60,12 +62,111 @@ RESOLUTION_LONG_EDGE = {
 }
 
 
-def build_handbrake_cmd(src, out, encoder, quality, preset, resolution="original"):
+# Encoder catalog. Each friendly `id` maps to a HandBrake `-e` name (`hb`), a
+# display `label`, whether it's hardware-accelerated (`hw`), a quality spec and
+# (software encoders only) the encoder option used to cap the CPU thread count.
+#
+# Quality scales differ per encoder, so the UI reads min/max/default and the
+# `qbetter` direction from here:
+#   - "low"  : RF/CRF/QP style, lower number = better quality (x265/x264/NVENC…)
+#   - "high" : VideoToolbox constant quality 0–100, higher = better
+#
+# `threadopt` is the HandBrake `--encopts` key that sets the thread/worker count
+# for that software encoder (verified: x265 `pools`, SVT-AV1 `lp`). HandBrake
+# manages x264 threading itself and ignores `threads`, so x264 (and every HW
+# encoder, where the GPU does the work) leave this None — no core control shown.
+ENCODER_CATALOG = [
+    {"id": "x265",       "hb": "x265",       "label": "HEVC (x265, CPU)",
+     "hw": False, "qmin": 18, "qmax": 32, "qdefault": 24, "qbetter": "low",  "threadopt": "pools"},
+    {"id": "svt_av1",    "hb": "svt_av1",    "label": "AV1 (SVT, CPU)",
+     "hw": False, "qmin": 18, "qmax": 45, "qdefault": 30, "qbetter": "low",  "threadopt": "lp"},
+    {"id": "x264",       "hb": "x264",       "label": "H.264 (x264, CPU)",
+     "hw": False, "qmin": 18, "qmax": 32, "qdefault": 22, "qbetter": "low",  "threadopt": None},
+    {"id": "vt_h265",    "hb": "vt_h265",    "label": "HEVC (Apple VideoToolbox)",
+     "hw": True,  "qmin": 1,  "qmax": 100, "qdefault": 60, "qbetter": "high", "threadopt": None},
+    {"id": "nvenc_h265", "hb": "nvenc_h265", "label": "HEVC (NVIDIA NVENC)",
+     "hw": True,  "qmin": 18, "qmax": 40, "qdefault": 24, "qbetter": "low",  "threadopt": None},
+    {"id": "qsv_h265",   "hb": "qsv_h265",   "label": "HEVC (Intel QSV)",
+     "hw": True,  "qmin": 18, "qmax": 40, "qdefault": 24, "qbetter": "low",  "threadopt": None},
+    {"id": "vaapi_h265", "hb": "vaapi_h265", "label": "HEVC (VAAPI)",
+     "hw": True,  "qmin": 18, "qmax": 40, "qdefault": 24, "qbetter": "low",  "threadopt": None},
+    {"id": "vce_h265",   "hb": "vce_h265",   "label": "HEVC (AMD VCE)",
+     "hw": True,  "qmin": 18, "qmax": 40, "qdefault": 24, "qbetter": "low",  "threadopt": None},
+]
+
+_CATALOG_BY_ID = {e["id"]: e for e in ENCODER_CATALOG}
+
+
+def encoder_spec(encoder):
+    """Catalog entry for a friendly encoder id, defaulting to x265."""
+    return _CATALOG_BY_ID.get(encoder, _CATALOG_BY_ID["x265"])
+
+
+@functools.lru_cache(maxsize=1)
+def _handbrake_encoder_names():
+    """Parse the `-e/--encoder` block of `HandBrakeCLI --help` into a name set.
+
+    Different HandBrake builds ship different encoders (e.g. vt_* only on macOS,
+    nvenc_*/qsv_* only on HW-enabled Linux builds), so we ask the binary rather
+    than assume. Cached: the answer can't change without restarting the process.
+    """
+    hb = shutil.which("HandBrakeCLI")
+    if not hb:
+        return frozenset()
+    try:
+        out = subprocess.run([hb, "--help"], capture_output=True, text=True, timeout=30)
+    except (subprocess.SubprocessError, OSError):
+        return frozenset()
+    text = (out.stdout or "") + "\n" + (out.stderr or "")
+    names, in_block = set(), False
+    for line in text.splitlines():
+        if "Select video encoder" in line:
+            in_block = True
+            continue
+        if in_block:
+            token = line.strip()
+            # The list is a contiguous block of single-token, indented names;
+            # the next option line ("--encoder-preset …") or any blank ends it.
+            if not token or " " in token or token.startswith("-"):
+                break
+            names.add(token)
+    return frozenset(names)
+
+
+def available_encoders():
+    """Catalog entries (UI-facing fields) the running HandBrake build supports."""
+    names = _handbrake_encoder_names()
+    return [
+        {"id": e["id"], "label": e["label"], "hw": e["hw"],
+         "qmin": e["qmin"], "qmax": e["qmax"], "qdefault": e["qdefault"],
+         "qbetter": e["qbetter"], "cores": bool(e["threadopt"])}
+        for e in ENCODER_CATALOG if e["hb"] in names
+    ]
+
+
+@functools.lru_cache(maxsize=1)
+def cpu_count():
+    """Usable CPU count for the encode worker (the preflight max for core choice).
+
+    Prefers the affinity mask (honours Linux cgroup/`taskset` limits) and falls
+    back to the logical CPU count on platforms without sched_getaffinity (macOS).
+    """
+    try:
+        return max(1, len(os.sched_getaffinity(0)))
+    except AttributeError:
+        return max(1, os.cpu_count() or 1)
+
+
+def build_handbrake_cmd(src, out, encoder, quality, preset, resolution="original", threads=None):
+    spec = encoder_spec(encoder)
     cmd = ["HandBrakeCLI", "-i", src, "-o", out,
-           "-e", ENCODER_MAP.get(encoder, "x265"),
-           "-q", str(quality)]
-    if encoder == "x265" and preset:
+           "-e", spec["hb"], "-q", str(quality)]
+    # Presets and CPU-thread caps only apply to the software encoders; hardware
+    # encoders ignore both (the GPU media engine does the work).
+    if not spec["hw"] and preset:
         cmd += ["--encoder-preset", str(preset)]
+    if not spec["hw"] and spec["threadopt"] and threads:
+        cmd += ["--encopts", f"{spec['threadopt']}={int(threads)}"]
     edge = RESOLUTION_LONG_EDGE.get(str(resolution))
     if edge:
         cmd += ["--maxWidth", str(edge), "--maxHeight", str(edge)]

--- a/backend/routes.py
+++ b/backend/routes.py
@@ -35,6 +35,7 @@ from backend.jobs import (
     do_recompress_motion, do_replace, do_strip_motion, emit_job_update,
     new_job, persist_if_terminal, public_job, update_job,
 )
+from backend.media import available_encoders, cpu_count
 
 bp = Blueprint("main", __name__)
 
@@ -88,6 +89,17 @@ def api_status():
         "ffprobe": ffprobe,
         "ffmpeg": ffmpeg,
         "immich_version": immich_version,
+    })
+
+
+@bp.route("/api/capabilities")
+def api_capabilities():
+    """Video encoders the running HandBrake build supports, plus the CPU-core
+    preflight max. Static for the process lifetime; the UI fetches it once to
+    populate the encoder dropdown and cap the CPU-cores control."""
+    return jsonify({
+        "encoders": available_encoders(),
+        "cpu_count": cpu_count(),
     })
 
 
@@ -436,6 +448,24 @@ def api_download(asset_id):
 # Routes: queue management
 # --------------------------------------------------------------------------- #
 
+def _clamp_threads(value):
+    """Clamp a requested CPU-thread count to [1, cpu_count()].
+
+    Returns None (encoder default = all cores) when unset, unparseable, or <= 0,
+    so the client's "0 = auto/all" sentinel never collapses to a single core.
+    Also caps a stale/oversized value to the detected core count.
+    """
+    if value is None:
+        return None
+    try:
+        n = int(value)
+    except (TypeError, ValueError):
+        return None
+    if n <= 0:
+        return None
+    return min(n, cpu_count())
+
+
 @bp.route("/api/enqueue", methods=["POST"])
 def api_enqueue():
     env = get_env()
@@ -456,6 +486,7 @@ def api_enqueue():
         "photo_target_savings": body.get("photo_target_savings", 40),
         "compress_raw": bool(body.get("compress_raw", False)),
         "preset": body.get("preset", "medium"),
+        "threads": _clamp_threads(body.get("threads")),
         "resolution": body.get("resolution", "original"),
         "motion_action": body.get("motion_action", "remove"),
         "skip_codecs": body.get("skip_codecs", "hevc,av1"),

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -19,6 +19,23 @@ services:
       # internet. To expose it, put it behind an authenticating reverse proxy and
       # only then change this to "${PORT:-5050}:${PORT:-5050}". See SECURITY.md.
       - "127.0.0.1:${PORT:-5050}:${PORT:-5050}"
+    # Hardware (GPU) video encoding — see the "Hardware acceleration" section in
+    # the README. The stock image's HandBrake has only CPU encoders; these become
+    # useful with a HandBrake build that includes NVENC/QSV. Uncomment to pass the
+    # GPU through:
+    #
+    # Intel/AMD (QSV / VAAPI):
+    # devices:
+    #   - /dev/dri:/dev/dri
+    #
+    # NVIDIA NVENC (needs the NVIDIA Container Toolkit on the host):
+    # deploy:
+    #   resources:
+    #     reservations:
+    #       devices:
+    #         - driver: nvidia
+    #           count: all
+    #           capabilities: [gpu]
     volumes:
       # Job-history SQLite DB.
       - immich-recompress-data:/data

--- a/frontend/src/app/app.ts
+++ b/frontend/src/app/app.ts
@@ -87,6 +87,7 @@ export class App implements OnInit {
       this.store.ffprobe.set(s.ffprobe);
       this.store.ffmpeg.set(s.ffmpeg);
     });
+    this.api.capabilities().subscribe(c => this.store.applyCapabilities(c));
     this.api.users().subscribe(data => this.store.users.set(data.users ?? []));
     this.api.keyOwners().subscribe(data => this.store.keyOwners.set(data.owners ?? []));
     this.api.jobs().subscribe(data => {

--- a/frontend/src/app/components/queue-panel/queue-panel.ts
+++ b/frontend/src/app/components/queue-panel/queue-panel.ts
@@ -84,11 +84,7 @@ export class QueuePanelComponent {
       return j.motion_action === 'recompress' ? 'Live Photo motion → recompressed' : 'Live Photo → still';
     }
     if (j.media === 'image') return `${from} → JPEG · .jpg`;
-    const ENC: Record<string, string> = {
-      x265: 'HEVC (x265)', nvenc_h265: 'HEVC (NVENC)',
-      qsv_h265: 'HEVC (QSV)', vce_h265: 'HEVC (VCE)',
-    };
-    const target = j.new_codec?.toUpperCase() ?? ENC[j.encoder] ?? j.encoder ?? 'HEVC';
+    const target = j.new_codec?.toUpperCase() ?? this.store.encoderLabel(j.encoder);
     return `${from} → ${target} · .mp4`;
   }
 }

--- a/frontend/src/app/components/review-modal/review-modal.html
+++ b/frontend/src/app/components/review-modal/review-modal.html
@@ -32,7 +32,7 @@
             @if (j.media === 'image') {
               <dt>Setting</dt><dd>Target savings {{ j.photo_target_savings ?? '—' }}%</dd>
             } @else {
-              <dt>Encoder</dt><dd>{{ j.encoder }} · RF {{ j.quality }} · {{ j.preset }}</dd>
+              <dt>Encoder</dt><dd>{{ encoderDetail(j) }}</dd>
             }
             @if (j.media === 'motionphoto') {
               <dt>Still Photo</dt><dd>Unchanged</dd>

--- a/frontend/src/app/components/review-modal/review-modal.ts
+++ b/frontend/src/app/components/review-modal/review-modal.ts
@@ -69,11 +69,16 @@ export class ReviewModalComponent {
         : 'Live Photo → still (motion video removed)';
     }
     if (j.media === 'image') return `${from} → JPEG · .jpg`;
-    const ENC: Record<string, string> = {
-      x265: 'HEVC (x265)', nvenc_h265: 'HEVC (NVENC)',
-      qsv_h265: 'HEVC (QSV)', vce_h265: 'HEVC (VCE)',
-    };
-    return `${from} → ${ENC[j.encoder] ?? j.encoder ?? 'HEVC'} · .mp4`;
+    return `${from} → ${this.store.encoderLabel(j.encoder)} · .mp4`;
+  }
+
+  /** Encoder summary line: friendly label, quality (RF or CQ), and preset for
+   *  software encoders only (hardware encoders don't use HandBrake presets). */
+  encoderDetail(j: JobPublic): string {
+    const e = this.store.encoders().find(x => x.id === j.encoder);
+    const term = e?.qbetter === 'high' ? 'CQ' : 'RF';
+    const head = `${this.store.encoderLabel(j.encoder)} · ${term} ${j.quality}`;
+    return (!e || !e.hw) ? `${head} · ${j.preset}` : head;
   }
 
   previewUrl(id: string, media: string): string {

--- a/frontend/src/app/components/settings-panel/settings-panel.html
+++ b/frontend/src/app/components/settings-panel/settings-panel.html
@@ -24,35 +24,60 @@
 
         <div class="field">
           <label>Encoder</label>
-          <select [ngModel]="s.encoder" (ngModelChange)="update({encoder: $event})">
-            <option value="x265">x265</option>
-            <option value="nvenc_h265">nvenc_h265</option>
-            <option value="qsv_h265">qsv_h265</option>
-            <option value="vce_h265">vce_h265</option>
-          </select>
-        </div>
-
-        <div class="field">
-          <label>Quality (RF): {{ s.quality }} · {{ rfLabel(s.quality) }}</label>
-          <div class="rangewrap">
-            <input type="range" min="18" max="32"
-              [ngModel]="s.quality" (ngModelChange)="update({quality: +$event})" />
-            <input type="number" min="18" max="32" class="num-input"
-              [ngModel]="s.quality" (ngModelChange)="update({quality: +$event})" />
-          </div>
-          <small>Constant-quality target for the encoder (HandBrake's RF, like CRF).
-            <strong>Lower = better quality &amp; bigger files; higher = smaller files &amp; lower quality.</strong>
-            Roughly each +6 halves the size. 18 ≈ near-lossless, ~22–26 is the sweet spot, 32 is small but visibly soft.</small>
-        </div>
-
-        <div class="field">
-          <label>Preset</label>
-          <select [ngModel]="s.preset" (ngModelChange)="update({preset: $event})">
-            @for (p of ['ultrafast','superfast','veryfast','faster','fast','medium','slow','slower','veryslow']; track p) {
-              <option [value]="p">{{ p }}</option>
+          <select [ngModel]="s.encoder" (ngModelChange)="onEncoder($event)">
+            @for (e of store.encoders(); track e.id) {
+              <option [value]="e.id">{{ e.label }}</option>
+            } @empty {
+              <option [value]="s.encoder">{{ s.encoder }}</option>
             }
           </select>
+          <small>Hardware (GPU) encoders are listed only when the running HandBrake
+            build supports them — they're far faster and barely touch the CPU.</small>
         </div>
+
+        <div class="field">
+          <label>Quality ({{ enc?.qbetter === 'high' ? 'CQ' : 'RF' }}): {{ s.quality }} · {{ qualityLabel(s.quality) }}</label>
+          <div class="rangewrap">
+            <input type="range" [min]="enc?.qmin ?? 18" [max]="enc?.qmax ?? 32"
+              [ngModel]="s.quality" (ngModelChange)="update({quality: +$event})" />
+            <input type="number" [min]="enc?.qmin ?? 18" [max]="enc?.qmax ?? 32" class="num-input"
+              [ngModel]="s.quality" (ngModelChange)="update({quality: +$event})" />
+          </div>
+          @if (enc?.qbetter === 'high') {
+            <small>Constant-quality target (0–100).
+              <strong>Higher = better quality &amp; bigger files; lower = smaller files.</strong>
+              ~55–65 is a good balance.</small>
+          } @else {
+            <small>Constant-quality target for the encoder (HandBrake's RF, like CRF).
+              <strong>Lower = better quality &amp; bigger files; higher = smaller files &amp; lower quality.</strong>
+              Roughly each +6 halves the size. 18 ≈ near-lossless, ~22–26 is the sweet spot, 32 is small but visibly soft.</small>
+          }
+        </div>
+
+        @if (!enc?.hw) {
+          <div class="field">
+            <label>Preset</label>
+            <select [ngModel]="s.preset" (ngModelChange)="update({preset: $event})">
+              @for (p of ['ultrafast','superfast','veryfast','faster','fast','medium','slow','slower','veryslow']; track p) {
+                <option [value]="p">{{ p }}</option>
+              }
+            </select>
+          </div>
+        }
+
+        @if (enc?.cores) {
+          <div class="field">
+            <label>CPU cores: {{ cores }} / {{ store.cpuCount() }}</label>
+            <div class="rangewrap">
+              <input type="range" min="1" [max]="store.cpuCount()"
+                [ngModel]="cores" (ngModelChange)="update({threads: +$event})" />
+              <input type="number" min="1" [max]="store.cpuCount()" class="num-input"
+                [ngModel]="cores" (ngModelChange)="update({threads: +$event})" />
+            </div>
+            <small>How many CPU cores the software encoder may use — {{ store.cpuCount() }} detected.
+              Fewer keeps the machine responsive; the max is fastest.</small>
+          </div>
+        }
 
         <div class="field">
           <label>Max Resolution</label>

--- a/frontend/src/app/components/settings-panel/settings-panel.ts
+++ b/frontend/src/app/components/settings-panel/settings-panel.ts
@@ -1,7 +1,7 @@
 import { ChangeDetectionStrategy, Component, inject, signal } from '@angular/core';
 import { FormsModule } from '@angular/forms';
 import { StoreService } from '../../services/store.service';
-import { Settings } from '../../models/api.models';
+import { EncoderInfo, Settings } from '../../models/api.models';
 
 @Component({
   selector: 'app-settings-panel',
@@ -17,35 +17,55 @@ export class SettingsPanelComponent {
   /** Whether the edit dialog is open. */
   readonly open = signal(false);
 
-  private readonly ENC: Record<string, string> = {
-    x265: 'HEVC (x265)', nvenc_h265: 'HEVC (NVENC)',
-    qsv_h265: 'HEVC (QSV)', vce_h265: 'HEVC (VCE)',
-  };
-
   get s(): Settings { return this.store.settings(); }
+
+  /** Spec of the currently-selected encoder (undefined until caps load). */
+  get enc(): EncoderInfo | undefined { return this.store.selectedEncoder(); }
 
   update(patch: Partial<Settings>): void {
     this.store.settings.update(s => ({ ...s, ...patch }));
     this.store.saveSettings();
   }
 
-  /** Plain-language band for an RF (rate-factor) value. */
-  rfLabel(rf: number): string {
-    if (rf <= 20) return 'near-lossless, large files';
-    if (rf <= 23) return 'high quality';
-    if (rf <= 26) return 'balanced';
-    if (rf <= 29) return 'smaller, some quality loss';
+  /** Switching encoders changes the quality scale, so reset quality to the new
+   *  encoder's default rather than carry an out-of-range value across scales. */
+  onEncoder(id: string): void {
+    const e = this.store.encoders().find(x => x.id === id);
+    this.update(e ? { encoder: id, quality: e.qdefault } : { encoder: id });
+  }
+
+  /** Effective CPU-core count (0/unset = all detected cores). */
+  get cores(): number { return this.s.threads || this.store.cpuCount(); }
+
+  /** Plain-language quality band, honouring the encoder's direction (RF-style
+   *  lower-is-better vs VideoToolbox 0–100 higher-is-better). */
+  qualityLabel(q: number): string {
+    if (this.enc?.qbetter === 'high') {
+      if (q >= 75) return 'near-lossless, large files';
+      if (q >= 60) return 'high quality';
+      if (q >= 45) return 'balanced';
+      if (q >= 30) return 'smaller, some quality loss';
+      return 'small files, visibly softer';
+    }
+    if (q <= 20) return 'near-lossless, large files';
+    if (q <= 23) return 'high quality';
+    if (q <= 26) return 'balanced';
+    if (q <= 29) return 'smaller, some quality loss';
     return 'small files, visibly softer';
   }
 
   // --- brief summary shown in the sidebar card ---
   get videoSummary(): string {
-    return `${this.ENC[this.s.encoder] ?? this.s.encoder} · RF ${this.s.quality}`;
+    const label = this.enc?.label ?? this.s.encoder;
+    const term = this.enc?.qbetter === 'high' ? 'CQ' : 'RF';
+    return `${label} · ${term} ${this.s.quality}`;
   }
 
   get outputSummary(): string {
     const res = this.s.resolution === 'original' ? 'Original' : `${this.s.resolution}p`;
-    return `${this.s.preset} · ${res}`;
+    const speed = this.enc && this.enc.hw ? 'hardware' : this.s.preset;
+    const cores = this.enc?.cores ? ` · ${this.cores} cores` : '';
+    return `${speed} · ${res}${cores}`;
   }
 
   get photoSummary(): string {

--- a/frontend/src/app/models/api.models.ts
+++ b/frontend/src/app/models/api.models.ts
@@ -85,6 +85,7 @@ export interface JobPublic {
   media: MediaType;
   encoder: string;
   quality: number;
+  threads: number | null;
   photo_target_savings: number;
   compress_raw: boolean;
   preset: string;
@@ -150,6 +151,7 @@ export interface Settings {
   media: MediaType;
   encoder: string;
   quality: number;
+  threads: number;
   photo_target_savings: number;
   compress_raw: boolean;
   preset: string;
@@ -159,6 +161,25 @@ export interface Settings {
   min_savings: number;
   replace: boolean;
   confirm: boolean;
+}
+
+/** One encoder the running HandBrake build supports (from /api/capabilities). */
+export interface EncoderInfo {
+  id: string;
+  label: string;
+  hw: boolean;
+  qmin: number;
+  qmax: number;
+  qdefault: number;
+  /** Quality direction: 'low' = lower is better (RF/CRF), 'high' = higher is better (VideoToolbox). */
+  qbetter: 'low' | 'high';
+  /** Whether a CPU-core count can be set for this (software) encoder. */
+  cores: boolean;
+}
+
+export interface Capabilities {
+  encoders: EncoderInfo[];
+  cpu_count: number;
 }
 
 export interface ProcessedEntry {

--- a/frontend/src/app/services/api.service.ts
+++ b/frontend/src/app/services/api.service.ts
@@ -2,7 +2,7 @@ import { inject, Injectable } from '@angular/core';
 import { HttpClient } from '@angular/common/http';
 import { Observable } from 'rxjs';
 import {
-  JobsResponse, Settings, StatusResponse, VideoDetail,
+  Capabilities, JobsResponse, Settings, StatusResponse, VideoDetail,
   VideosResponse, VideoSummary, User, KeyOwner, MediaType, SortField, SortOrder,
 } from '../models/api.models';
 
@@ -12,6 +12,10 @@ export class ApiService {
 
   status(): Observable<StatusResponse> {
     return this.http.get<StatusResponse>('/api/status');
+  }
+
+  capabilities(): Observable<Capabilities> {
+    return this.http.get<Capabilities>('/api/capabilities');
   }
 
   assets(params: {

--- a/frontend/src/app/services/store.service.ts
+++ b/frontend/src/app/services/store.service.ts
@@ -1,7 +1,7 @@
 import { computed, effect, Injectable, signal } from '@angular/core';
 import {
-  JobPublic, JobStatus, KeyOwner, MediaType, ProcessedEntry, Settings, SortField, SortOrder,
-  SseJobUpdate, User, VideoSummary,
+  Capabilities, EncoderInfo, JobPublic, JobStatus, KeyOwner, MediaType, ProcessedEntry,
+  Settings, SortField, SortOrder, SseJobUpdate, User, VideoSummary,
 } from '../models/api.models';
 
 const LS_BROWSE = 'immich_browse';
@@ -64,6 +64,13 @@ export class StoreService {
   readonly ffprobe = signal(false);
   readonly ffmpeg = signal(false);
 
+  // --- encoder/CPU capabilities (from /api/capabilities) ---
+  readonly encoders = signal<EncoderInfo[]>([]);
+  readonly cpuCount = signal(1);
+  /** The encoder spec for the current settings, or undefined until caps load. */
+  readonly selectedEncoder = computed(() =>
+    this.encoders().find(e => e.id === this.settings().encoder));
+
   // --- queue ---
   readonly jobs = signal<Record<string, JobPublic>>({});
   readonly activeId = signal<string | null>(null);
@@ -80,6 +87,7 @@ export class StoreService {
     media: 'video',
     encoder: 'x265',
     quality: 24,
+    threads: 0,  // 0 = use all cores; set to the detected max once caps load
     photo_target_savings: 40,
     compress_raw: false,
     preset: 'medium',
@@ -124,7 +132,9 @@ export class StoreService {
       if (q >= q1 && q <= q2) { frac = f1 + (f2 - f1) * ((q - q1) / (q2 - q1)); break; }
       if (q > q2) frac = f2;
     }
-    const mult = s.encoder === 'x265' ? (PRESET_SAVINGS_MULT[s.preset] ?? 1.0) : 0.9;
+    // Software encoders gain efficiency from slower presets; hardware encoders
+    // ignore presets and trade a little ratio for speed.
+    const mult = this.selectedEncoder()?.hw ? 0.9 : (PRESET_SAVINGS_MULT[s.preset] ?? 1.0);
     return Math.max(0, Math.min(0.95, frac * mult));
   });
 
@@ -143,7 +153,7 @@ export class StoreService {
         const [w, h] = v.resolution.split('x').map(Number);
         if (w && h) res = Math.min(8, Math.max(0.3, (w * h) / (1920 * 1080)));
       }
-      const rt = s.encoder === 'x265' ? (PRESET_REALTIME[s.preset] ?? 1.3) : 0.15;
+      const rt = this.selectedEncoder()?.hw ? 0.15 : (PRESET_REALTIME[s.preset] ?? 1.3);
       return sum + dur * rt * res;
     }, 0);
   });
@@ -222,6 +232,34 @@ export class StoreService {
     try {
       localStorage.setItem(LS_SETTINGS, JSON.stringify(this.settings()));
     } catch { /* ignore */ }
+  }
+
+  /** Friendly label for an encoder id, from detected capabilities; falls back
+   *  to the raw id (e.g. for a historical job whose encoder this build lacks). */
+  encoderLabel(id: string): string {
+    return this.encoders().find(e => e.id === id)?.label ?? id ?? 'HEVC';
+  }
+
+  /** Apply the runtime encoder/CPU capabilities: reconcile persisted settings
+   *  with what the running HandBrake build actually supports. */
+  applyCapabilities(caps: Capabilities): void {
+    const encoders = caps.encoders ?? [];
+    const cpu = Math.max(1, caps.cpu_count || 1);
+    this.encoders.set(encoders);
+    this.cpuCount.set(cpu);
+    this.settings.update(s => {
+      const next = { ...s };
+      // Default/clamp the CPU-core count to the detected max (0 = unset → all).
+      if (!next.threads || next.threads > cpu) next.threads = cpu;
+      // If the persisted encoder isn't available in this build, fall back to the
+      // first available one and reset quality to that encoder's default scale.
+      if (encoders.length && !encoders.some(e => e.id === next.encoder)) {
+        next.encoder = encoders[0].id;
+        next.quality = encoders[0].qdefault;
+      }
+      return next;
+    });
+    this.saveSettings();
   }
 
   markProcessed(id: string, job: JobPublic): void {


### PR DESCRIPTION
Implements multi-core CPU and GPU acceleration for video encoding.

## Summary
- Runtime-detect the encoders the installed HandBrake build supports and expose them via a new `GET /api/capabilities`; the encoder dropdown only offers what actually works.
- OS-agnostic GPU encoding (Apple VideoToolbox, NVENC, Intel QSV/VAAPI) when the build supports it.
- Selectable CPU-core count (preflight max) for software encoders via HandBrake `--encopts pools/lp`.
- Fix the encode progress bar (was stuck at 1%/100%): read progress from stdout, parse the value attached to the `%`, and ignore the pre-encode scan phase.
- Docker GPU passthrough scaffolding + docs.

Closes #1
